### PR TITLE
changed http:// to https:// for W3C stylesheets

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -7,8 +7,8 @@
   <title>Map Markup Language</title>
   
   <!-- <link class="required" rel="stylesheet" href="w3c-unofficial.css" type="text/css"/> -->
-  <link class="required" rel="stylesheet" href="http://www.w3.org/StyleSheets/TR/w3c-unofficial.css" type="text/css"/>
-  <link rel="stylesheet" type="text/css" href="http://www.w3.org/StyleSheets/TR/w3c-tr.css" />
+  <link class="required" rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/w3c-unofficial.css" type="text/css"/>
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/w3c-tr.css" />
   <style>
         .content { background-image: none; }
         h5 { position: relative; z-index: 3; }
@@ -69,7 +69,7 @@ dl.domintro {padding: 0.5em 1em; border: none; background:#E9FBE9; border: 1px s
   <dd><em>https://github.com/Maps4HTML/MapML/tree/5341da6017979c7afa31cb14643f0175e0630ba2</em></dd>
   
   <dt>Latest version:</dt>
-  <dd><em>http://maps4html.github.io/MapML/spec/</em></dd>
+  <dd><em>https://maps4html.github.io/MapML/spec/</em></dd>
   
   <dt>Previous version:</dt>
   <dd><em>https://github.com/Maps4HTML/MapML/tree/a1afe0d8c71ce850eaa6822a178b4365fcb9cd4c</em></dd>


### PR DESCRIPTION
to avoid browsers blocking 'mixed active content'

https://maps4html.github.io/MapML/spec/ breaks for me in both Firefox and Chromium
https://elf-pavlik.github.io/MapML/spec/ with this patch works just fine