### PR TITLE
Minor clean-up

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -73,13 +73,13 @@ function googleTranslateElementInit() {
 
 <dl>
   <dt>This version:</dt>
-  <dd><em>https://github.com/Maps4HTML/MapML/</em></dd>
+  <dd><a href="https://github.com/Maps4HTML/MapML/" target="_blank">https://github.com/Maps4HTML/MapML/</a></dd>
   
   <dt>Latest version:</dt>
-  <dd><em>https://maps4html.github.io/MapML/spec/</em></dd>
+  <dd><a href="https://maps4html.github.io/MapML/spec/" target="_blank">https://maps4html.github.io/MapML/spec/</a></dd>
   
   <dt>Previous version:</dt>
-  <dd><em>https://github.com/Maps4HTML/MapML/</em></dd>
+  <dd><a href="https://github.com/Maps4HTML/MapML/" target="_blank">https://github.com/Maps4HTML/MapML/</a></dd>
   
   <dt>Editors:</dt>
 	<dd><em>Peter Rushforth</em>, Natural Resources Canada</dd>
@@ -94,7 +94,7 @@ function googleTranslateElementInit() {
 </dl>
 
 
-<p>Copyright © 2015-2019 the Contributors to Map Markup Language, published by the  <a href="https://www.w3.org/community/maps4html/">Maps for HTML Community Group</a> under the <a href="http://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
+<p>Copyright © 2015-2019 the Contributors to Map Markup Language, published by the  <a href="https://www.w3.org/community/maps4html/">Maps for HTML Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
 </p>
 
 </div>
@@ -410,7 +410,7 @@ property value domain</p>
   </dl>
   <p>This document contains explicit conformance criteria that overlap with some RNG definitions in requirements. If there is any conflict between the two, the explicit conformance criteria are the definitive reference. </p>
 	
-	<p>Within this specification, the key words "MUST, "MUST NOT", "REQUIRED, "SHALL, "SHALL NOT, "SHOULD, "SHOULD NOT", "RECOMMENDED, "MAY", and "OPTIONAL" are to be interpreted as described in <a href="http://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a> [<a href="ref-RFC2119">RFC2119</a>].  However, for readability, these words do not necessarily appear in uppercase in this specification.</p>
+	<p>Within this specification, the key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a> [<a href="ref-RFC2119">RFC2119</a>].  However, for readability, these words do not necessarily appear in uppercase in this specification.</p>
 
 </div>
 
@@ -1754,7 +1754,7 @@ property value domain</p>
 
 	<h2 id="rng">8.1. RelaxNG Schema</h2>
 
-	<p>Map Markup Language provides a schema written in <a href="http://www.y12.doe.gov/sgml/sc34/document/0362_files/relaxng-is.pdf">RelaxNG compact syntax</a> [<a href="#ref-RNG">RelaxNG</a>], a namespace-aware schema language that uses the datatypes from <a href="https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/">XML Schema Part 2</a> [<a href="#ref-Schema2">Schema2</a>]. </p>
+	<p>Map Markup Language provides a schema written in <a href="https://web.archive.org/web/20120619140335/http://www1.y12.doe.gov/capabilities/sgml/sc34/document/0362_files/relaxng-is.pdf">RelaxNG compact syntax</a> [<a href="#ref-RNG">RelaxNG</a>], a namespace-aware schema language that uses the datatypes from <a href="https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/">XML Schema Part 2</a> [<a href="#ref-Schema2">Schema2</a>]. </p>
  
  <p>Further map document validation can be done with Schematron. Please see the MapML schema directory for further information.</p>
 
@@ -1774,17 +1774,17 @@ property value domain</p>
 
     <dt id="ref-RFC2119"><strong class="normref">[RFC2119]</strong></dt>
     <dd>
-      <cite><a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>,
+      <cite><a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>,
       S. Bradner, March 1997.
-      <br />Available at http://tools.ietf.org/html/rfc2119.
+      <br />Available at https://tools.ietf.org/html/rfc2119.
     </dd>
 
     <dt id="ref-RNG"><strong class="normref">[RELAXNG]</strong></dt>
 	  <dd>
-	    <cite><a href="http://www.y12.doe.gov/sgml/sc34/document/0362_files/relaxng-is.pdf">Document Schema Definition Languages (DSDL) — Part 2: Regular grammar-based validation — RELAX NG, ISO/IEC FDIS 19757-2:2002(E)</a></cite>,
+	    <cite><a href="https://web.archive.org/web/20120619140335/http://www1.y12.doe.gov/capabilities/sgml/sc34/document/0362_files/relaxng-is.pdf">Document Schema Definition Languages (DSDL) — Part 2: Regular grammar-based validation — RELAX NG, ISO/IEC FDIS 19757-2:2002(E)</a></cite>,
 	    J. Clark, <ruby><rb xml:lang="ja" lang="ja">村田 真</rb> <rp>(</rp><rt><span class="familyname">Murata</span> M.</rt><rp>)</rp></ruby>, eds.
 	    International Organization for Standardization, 12 December 2002.
-	    <br/>Available at http://www.y12.doe.gov/sgml/sc34/document/0362_files/relaxng-is.pdf.
+	    <br/>Available at https://web.archive.org/web/20120619140335/http://www1.y12.doe.gov/capabilities/sgml/sc34/document/0362_files/relaxng-is.pdf.
 	  </dd>
 	</dl>
 
@@ -1809,8 +1809,8 @@ property value domain</p>
       C. McCormack, ed.
       World Wide Web Consortium, <span class="wip">work in progress</span>, 19 December 2008.
       <br />This edition of WebIDL is https://www.w3.org/TR/2008/WD-WebIDL-20081219/.
-      <br />The <a href="https://dev.w3.org/2006/webapi/WebIDL/">latest edition of WebIDL</a> is available at
-      https://dev.w3.org/2006/webapi/WebIDL/.
+      <br />The <a href="https://www.w3.org/TR/WebIDL/">latest edition of WebIDL</a> is available at
+      https://www.w3.org/TR/WebIDL/.
     </dd>
 
 	  <dt id="ref-MicroXML"><strong class="informref">[MicroXML]</strong></dt>
@@ -1824,13 +1824,13 @@ property value domain</p>
 	    I. Hickson, R. Berjon, S. Faulkner, T. Leithead E. Doyle Navara, E. O'Connor, S. Pfeiffer, eds. World Wide Web Consortium, 28 October 2014.
 	  </dd>
 	  <dt id="BCP47"><strong class="informref">[BCP47]</strong></dt>
-    <dd><cite><a href="https://www.ietf.org/rfc/bcp/bcp47.txt">Tags for Identifying Languages; Matching of Language Tags</a> (URL: <a href="http://www.ietf.org/rfc/bcp/bcp47.txt">http://www.ietf.org/rfc/bcp/bcp47.txt</a>)</cite>, A. Phillips, M. Davis. IETF.</dd>
+    <dd><cite><a href="https://www.ietf.org/rfc/bcp/bcp47.txt">Tags for Identifying Languages; Matching of Language Tags</a> (URL: <a href="https://www.ietf.org/rfc/bcp/bcp47.txt">https://www.ietf.org/rfc/bcp/bcp47.txt</a>)</cite>, A. Phillips, M. Davis. IETF.</dd>
 	  <dt id="ref-GeoJSON"><strong class="informref">[GeoJSON]</strong></dt>
-	  <dd><cite><a href="http://geojson.org/">The GeoJSON Format Specification</a></cite></dd>
+	  <dd><cite><a href="https://geojson.org/">The GeoJSON Format Specification</a></cite></dd>
 	  <dt id="ref-OSMTILE"><strong class="informref">[OSMTILE]</strong></dt>
-	  <dd><cite><a href="http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames">Open Street Map Slippy Maps Tilenames Wiki</a></cite></dd>
+	  <dd><cite><a href="https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames">Open Street Map Slippy Maps Tilenames Wiki</a></cite></dd>
 	  <dt id="ref-EPSG-REGISTRY"><strong class="informref">[EPSG-REGISTRY]</strong></dt>
-	  <dd><cite><a href="http://www.epsg-registry.org/">EPSG Geodetic Parameter Registry</a></cite></dd>
+	  <dd><cite><a href="https://www.epsg-registry.org/">EPSG Geodetic Parameter Registry</a></cite></dd>
 	  
 	</dl>
 	


### PR DESCRIPTION
Fix broken links, replace http with https, add missing double quotes `"` in key words. Make spec version links into anchors.