### PR TITLE
Move from single-page to multi-page WHATWG references

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -841,13 +841,13 @@
         <p>This section is normative.</p>
 
         <h4 id="the-map-element"><em>4.1.1 The <dfn><code>&lt;map&gt;</code></dfn> element</em></h4>
-        <dl class="element"><dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
-        <dd><a target="_blank" href="https://html.spec.whatwg.org/#flow-content-2">Flow content</a>.</dd>
-        <dd><a target="_blank" href="https://html.spec.whatwg.org/#phrasing-content-2">Phrasing content</a>.</dd>
+        <dl class="element"><dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
+        <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>.</dd>
+        <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>.</dd>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a>.</dd>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#embedded-content-2">Embedded content</a>.</dd>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>.</dd>
-        <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+        <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
         <dd><em>Where <a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#embedded-content-2">embedded content</a> is expected.</em></dd>
         <dt id="map-content"><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
         <dd><em>If <a href="#attr-map-lat">lat</a>, <a href="#attr-map-lon">lon</a>, and <a href="#attr-map-zoom">zoom</a>
@@ -862,7 +862,7 @@
         <dd id="attr-map-controls"><em><code><a href="#attr-map-controls">controls</a></code> - Show user agent map controls</em></dd>
         <dd id="attr-map-width"><em><code><a href="#attr-map-width">width</a></code> - Horizontal dimension</em></dd>
         <dd id="attr-map-height"><em><code><a href="#attr-map-height">height</a></code> - Vertical dimension</em></dd>
-        <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-tag-omission">Tag omission in text/html</a>:</dt>
+        <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-tag-omission">Tag omission in text/html</a>:</dt>
         <dd>Neither tag is omissible</dd>
         <dt>Allowed <a target="_blank" href="https://www.w3.org/TR/2014/REC-html5-20141028/dom.html#aria-role-attribute">ARIA role attribute</a> values:</dt>
         <dd><a target="_blank" href="https://www.w3.org/TR/html-aria/#index-aria-application"><code title="">application</code></a></dd>
@@ -927,18 +927,18 @@
         </div>
 
         <h4 id="the-layer-element"><em>4.1.2 The <dfn><code>&lt;layer&gt;</code></dfn> element</em></h4>
-        <dl class="element"><dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
-        <dd><a target="_blank" href="https://html.spec.whatwg.org/#flow-content-2">Flow content</a>.</dd>
-        <dd><a target="_blank" href="https://html.spec.whatwg.org/#phrasing-content-2">Phrasing content</a>.</dd>
+        <dl class="element"><dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
+        <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>.</dd>
+        <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>.</dd>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a>.</dd>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#embedded-content-2">Embedded content</a>.</dd>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>.</dd>
-        <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+        <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
         <dd>As a child of the <a href="#the-map-element">map</a> element</dd>
         <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
         <dd>If the <a href="#attr-layer-src"><code>src</code></a> attribute is present: <a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing">Nothing</a>. 
         If no <a href="#attr-layer-src"><code>src</code></a> attribute is present: 
-        <a target="_blank" href="https://html.spec.whatwg.org/#metadata-content-2">Metadata content</a> describing nested <a href="#structure">Map Markup Language</a> content</dd>
+        <a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#metadata-content-2">Metadata content</a> describing nested <a href="#structure">Map Markup Language</a> content</dd>
         <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">Content attributes</a>:</dt>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">Global attributes</a></dd>
         <dd id="attr-layer-src"><em><code><a href="#attr-layer-src">src</a></code> - Address of the resource</em></dd>
@@ -948,7 +948,7 @@
         <dd id="attr-layer-hidden"><em><code><a href="#attr-layer-hidden">hidden</a></code> - Visibility status of the layer in the layer control</em></dd>
         <dd id="attr-layer-referrerpolicy"><em><code><a href="#attr-layer-referrerpolicy">referrerpolicy</a></code> - <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">Referrer policy</a> for <a href="https://fetch.spec.whatwg.org/#concept-fetch">fetches</a> initiated by the element</em></dd>
         <dd id="attr-layer-crossorigin"><em><code><a href="#attr-layer-crossorigin">crossorigin</a></code> - A <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute">CORS settings attribute</a>, specifies how the element handles crossorigin requests</em></dd>
-        <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-tag-omission">Tag omission in text/html</a>:</dt>
+        <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-tag-omission">Tag omission in text/html</a>:</dt>
         <dd>Neither tag is omissible</dd>
         <dt>Allowed <a target="_blank" href="https://www.w3.org/TR/2014/REC-html5-20141028/dom.html#aria-role-attribute">ARIA role attribute</a> values:</dt>
         <dd>None</dd>
@@ -996,10 +996,10 @@
 
         </div>
         <h4 id="the-area-element"><em>4.1.3 The <dfn><code>&lt;area&gt;</code></dfn> element</em></h4>
-        <dl class="element"><dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
-        <dd><a target="_blank" href="https://html.spec.whatwg.org/#flow-content-2">Flow content</a>.</dd>
-        <dd><a target="_blank" href="https://html.spec.whatwg.org/#phrasing-content-2">Phrasing content</a>.</dd>
-        <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+        <dl class="element"><dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
+        <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>.</dd>
+        <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>.</dd>
+        <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
         <dd>As a child of the <a href="#the-map-element">map</a> element</dd>
         <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
         <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing">Nothing</a>.</dd>
@@ -1009,7 +1009,7 @@
         <dd id="attr-area-alt"><em><code><a href="#attr-area-alt">alt</a></code> - User-visible label</em></dd>
         <dd id="attr-area-coords"><em><code><a href="#attr-area-coords">coords</a></code> - Coordinates for the shape to be created on the map</em></dd>
         <dd id="attr-area-shape"><em><code><a href="#attr-area-shape">shape</a></code> - The kind of shape to be created on the map</em></dd>
-        <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-tag-omission">Tag omission in text/html</a>:</dt>
+        <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-tag-omission">Tag omission in text/html</a>:</dt>
         <dd>Neither tag is omissible</dd>
         <dt>Allowed <a target="_blank" href="https://www.w3.org/TR/2014/REC-html5-20141028/dom.html#aria-role-attribute">ARIA role attribute</a> values:</dt>
         <dd><a target="_blank" href="https://www.w3.org/TR/wai-aria-1.1/#link"><code>link</code></a> role (default - <a target="_blank" href="https://www.w3.org/TR/html-aria/#el-area">do not set</a>).</dd>
@@ -1576,9 +1576,9 @@
         </p>
         <h5 id="the-mapml-element">5.2.2 The <code>&lt;mapml&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>n/a</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>The root of a MapML document</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>One <code>&lt;head&gt;</code> element, followed by one <code>&lt;body&gt;</code> element</dd>
@@ -1595,9 +1595,9 @@
         <p>The <code>&lt;mapml&gt;</code> element may carry a <code>lang</code> attribute, as <a href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">defined</a> by [<a href="#ref-HTML">HTML</a>].</p>
         <h5 id="the-head-element">5.2.3 The <code>&lt;head&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#metadata-content-2">Metadata content</a></dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>As the first child element of the <code>&lt;mapml&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>One or more elements of metadata content, of which exactly one is a <code>title</code> element and no more than one is a <code>base</code> element.</dd>
@@ -1615,9 +1615,9 @@
         </p>
         <h5 id="the-title-element">5.2.4 The <code>&lt;title&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#metadata-content-2">Metadata content</a></dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>As a child of the <code>&lt;head&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>Text</dd>
@@ -1635,9 +1635,9 @@
         </p>
         <h5 id="the-base-element">5.2.5 The <code>&lt;base&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#metadata-content-2">Metadata content</a></dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>As a child element of the <code>&lt;head&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing">Nothing</a>.</dd>
@@ -1657,9 +1657,9 @@
         </p>
         <h5 id="the-meta-element">5.2.6 The <code>&lt;meta&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#metadata-content-2">Metadata content</a></dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>In the <code>&lt;head&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing">Nothing</a>.</dd>
@@ -1679,9 +1679,9 @@
         </dl>
         <h5 id="the-link-element">5.2.7 The <code>&lt;link&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#metadata-content-2">Metadata content</a></dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>If the element represents a hyperlink (has a <code>href</code> attribute): as a child of the <code>head</code> or <code>body</code> element.</dd>
           <dd>If the element represents a link template (has a <code>tref</code> attribute): as a child of the <code>extent</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
@@ -1880,9 +1880,9 @@
         </table>
         <h5 id="the-body-element">5.2.8 The <code>&lt;body&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>n/a</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>As the second child of the <code>&lt;mapml&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>Features and metadata</dd>
@@ -1898,9 +1898,9 @@
         <p>The <code>&lt;body&gt;</code> element represents the content of the document.</p>
         <h5 id="the-extent-element">5.2.9 The <code>&lt;extent&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#metadata-content-2">Metadata content</a></dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>Required to be a child of the <code>&lt;body&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>
@@ -1932,9 +1932,9 @@
 
         <h5 id="the-input-element">5.2.10 The <code>&lt;input&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>n/a</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>Required to be a child of the <code>&lt;extent&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing">Nothing</a>.</dd>
@@ -2212,9 +2212,9 @@
         </table>
         <h5 id="the-datalist-element">5.2.11 The <code>&lt;datalist&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>n/a</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>
             As a child of the <a href="#the-extent-element"><code>extent</code></a> element, associated to an <a href="#the-input-element"><code>input</code></a> element via that element's <code>list</code> attribute.
           </dd>
@@ -2234,9 +2234,9 @@
         </dl>
         <h5 id="the-label-element">5.2.12 The <code>&lt;label&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>n/a</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>
             As a child of the <a href="#the-extent-element"><code>extent</code></a> element.
           </dd>
@@ -2254,9 +2254,9 @@
         </dl>
         <h5 id="the-select-element">5.2.13 The <code>&lt;select&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>n/a</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>
             As a child of the <a href="#the-extent-element"><code>extent</code></a> element.
           </dd>
@@ -2278,9 +2278,9 @@
         </dl>
         <h5 id="the-option-element">5.2.14 The <code>&lt;option&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>n/a</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>
             As a child of the <a href="#the-select-element"><code>select</code></a> element or the <a href="#the-datalist-element"><code>datalist</code></a> element.
           </dd>
@@ -2301,9 +2301,9 @@
 
         <h5 id="the-tile-element">5.2.15 The <code>&lt;tile&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>Feature data</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>Child of the <code>&lt;body&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing">Nothing</a>.</dd>
@@ -2340,9 +2340,9 @@
         </p>
         <h5 id="the-image-element">5.2.16 The <code>&lt;image&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>Feature data</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>A child of the <code>&lt;feature&gt;</code> element, which has a sibling <code>bbox</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-content-nothing">Nothing</a>.</dd>
@@ -2358,9 +2358,9 @@
 
         <h5 id="the-feature-element">5.2.17 The <code>&lt;feature&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>Feature data</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>Child of the <code>&lt;body&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>An optional <code>bbox</code> element, followed by either an <code>image</code> or <code>geometry</code> element, followed by an optional <code>properties</code> element.</dd>
@@ -2380,9 +2380,9 @@
         </p>
         <h5 id="the-properties-element">5.2.18 The <code>&lt;properties&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>Feature data</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>A child of the <code>&lt;feature&gt;</code> element, containing elements representing the properties of the feature.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>One or more unknown elements with text values. TODO allow HTML content.</dd>
@@ -2401,9 +2401,9 @@
 
         <h5 id="the-geometry-element">5.2.19 The <code>&lt;geometry&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>Feature data</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>Child of the <code>&lt;feature&gt;</code> element.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>A single geometry value, described in the <a href="#geometry-values">table</a> below.</dd>
@@ -2495,9 +2495,9 @@
         </table>
         <h5 id="the-coordinates-element">5.2.20 The <code>&lt;coordinates&gt;</code> element</h5>
         <dl class="element">
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-categories">Categories</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-categories">Categories</a>:</dt>
           <dd>Feature data</dd>
-          <dt><a target="_blank" href="https://html.spec.whatwg.org/#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
+          <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-contexts">Contexts in which this element can be used</a>:</dt>
           <dd>A descendant of the <code>&lt;geometry&gt;</code> element, as the coordinate data which defines a feature geometry.</dd>
           <dt><a target="_blank" href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model">Content model</a>:</dt>
           <dd>One or more <a href="#position">position</a>s in x followed by y, separated by whitespace, with each position separated from the adjacent position by whitespace.</dd>
@@ -2639,7 +2639,7 @@
     </dd>
           <dt id="ref-HTML"><strong class="informref">[HTML]</strong></dt>
 	  <dd>
-            <cite class="w3crec"><a href="https://html.spec.whatwg.org/">HTML</a></cite>,
+            <cite class="w3crec"><a href="https://html.spec.whatwg.org/multipage/">HTML</a></cite>,
             Anne van Kesteren; et al. HTML Standard. Living Standard. URL: https://html.spec.whatwg.org/multipage/
 	  </dd>
           <dt id="BCP47"><strong class="informref">[BCP47]</strong></dt>


### PR DESCRIPTION
For performance reasons, we should use multi-page references (https://html.spec.whatwg.org/multipage/#the-thing) everywhere as opposed to the single-page version (https://html.spec.whatwg.org/#the-thing). The single-page loads in a lot slower.

In fact it seems WHATWG themselves mostly link to multi-page(s), and I have seemingly been inconsistent with this, prior to this PR.