### PR TITLE
Content attribute definitions & IDL reflections in <map>

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -687,7 +687,7 @@
 
         <p>The location and zoom level of the map created with the <a href="#the-map-element"><code>map</code></a> element can be changed via the <code>zoomTo()</code> API method, which will change the <code>zoom</code>, <code>lat</code> and <code>lon</code> properties.</p>
 
-        <p>The <dfn id="attr-map-controls"><code>controls</code></dfn> attribute is a <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute">boolean attribute</a>. If present, it indicates that the author has not provided a scripted controller and would like the user agent to provide its own set of controls.</p>
+        <p>The <dfn id="attr-map-controls"><code>controls</code></dfn> attribute is a <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute">boolean attribute</a>. If present, it indicates that the author has not provided scripted controls and would like the user agent to provide its own set of controls.</p>
         <!-- https://html.spec.whatwg.org/multipage/media.html#user-interface -->
         <p>If the attribute is present, or if <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-noscript">scripting is disabled</a> for the <a href="https://html.spec.whatwg.org/multipage/media.html#media-element">media element</a>, then the user agent should <dfn id="expose-a-user-interface-to-the-user"><strong>expose a user interface to the user</strong></dfn>.
           This user interface should include features to zoom in, zoom out, pan to an arbitrary position in the content, and show the media content in manners more suitable to the user (e.g. fullscreen map or in an independent resizable window). Other controls may also be made available.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -621,13 +621,13 @@
 
         <dt><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes">Content attributes</a>:</dt>
         <dd><a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">Global attributes</a>.</dd>
-        <dd><code id="attr-map-zoom">zoom</code> — A positive integer zoom (scale) value.</dd>
-        <dd><code id="attr-map-lat">lat</code> — A decimal WGS84 latitude value for the map center.</dd>
-        <dd><code id="attr-map-lon">lon</code> — A decimal WGS84 longitude value for the map center.</dd>
-        <dd><code id="attr-map-projection">projection</code> — A case-sensitive string <a href="#tiled-coordinate-reference-systems-table">identifier</a> of the MapML coordinate reference system used by the map. Default is <a href="#tcrs-OSMTILE"><code>OSMTILE</code></a>.</dd>
-        <dd><code id="attr-map-controls">controls</code> — Show user agent map controls.</dd>
-        <dd><code id="attr-map-width">width</code> — Horizontal dimension.</dd>
-        <dd><code id="attr-map-height">height</code> — Vertical dimension.</dd>
+        <dd><code>zoom</code> — A positive integer zoom (scale) value.</dd>
+        <dd><code>lat</code> — A decimal WGS84 latitude value for the map center.</dd>
+        <dd><code>lon</code> — A decimal WGS84 longitude value for the map center.</dd>
+        <dd><code>projection</code> — A case-sensitive string <a href="#tiled-coordinate-reference-systems-table">identifier</a> of the MapML coordinate reference system used by the map. Default is <a href="#tcrs-OSMTILE"><code>OSMTILE</code></a>.</dd>
+        <dd><code>controls</code> — Show user agent map controls.</dd>
+        <dd><code>width</code> — Horizontal dimension.</dd>
+        <dd><code>height</code> — Vertical dimension.</dd>
         <dt><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-element-tag-omission">Tag omission in text/html</a>:</dt>
         <dd>Neither tag is omissible.</dd>
         <dt>Allowed <a href="https://www.w3.org/TR/2014/REC-html5-20141028/dom.html#aria-role-attribute">ARIA role attribute</a> values:</dt>
@@ -643,9 +643,9 @@
             
             [SameObject] readonly attribute HTMLCollection layers;
             [SameObject] readonly attribute HTMLCollection areas;
-            readonly attribute unsigned short zoom;
-            readonly attribute double lat;
-            readonly attribute double lon;
+            [CEReactions] attribute unsigned short zoom;
+            [CEReactions] attribute double lat;
+            [CEReactions] attribute double lon;
             readonly attribute DOMString projection;
             [CEReactions] attribute boolean controls;
             [CEReactions] attribute unsigned long width;
@@ -656,41 +656,51 @@
         </dd>
         </dl>
         <div>
+          
         <p id="implementation">The <a href="#the-map-element"><code>map</code></a> element, in conjunction with child <a href="#the-layer-element"><code>layer</code></a> and optionally 
-        <a href="#the-area-element"><code>area</code></a> elements, allows authors to embed an interactive web mapping application in a rectangular area of a web page.  
-        The <a href="#attr-map-lat"><code>lat</code></a>, <a href="#attr-map-lon"><code>lon</code></a> attributes locate the initial center of the map.  The 
-        <a href="#attr-map-zoom"><code>zoom</code></a> attribute indirectly identifies an initial scale of the map.
-        After initialization, the <code>lat</code>,<code>lon</code> and <code>zoom</code> IDL properties reflect the location and scale of the map respectively, based on changes initiated
-        by the user or by script.</p>
-        <dl class="domintro"><dt><var>map</var> . <a href="#dom-areas"><code>areas</code></a></dt>
+        <a href="#the-area-element"><code>area</code></a> elements, defines a map <a href="https://html.spec.whatwg.org/multipage/media.html#media-element">media element</a>.</p>
+          
+        <dl class="def"><dt><var>map</var> . <a href="#dom-areas"><code>areas</code></a></dt>
         <dd>
-        <p>Returns an <code>HTMLCollection</code> of the 
+        <p>Returns an <a href="https://dom.spec.whatwg.org/#htmlcollection"><code>HTMLCollection</code></a> of the 
         <a href="#the-area-element"><code>area</code></a> elements in the
         <a href="#the-map-element"><code>map</code></a>.</p>
         </dd>
         <dt><var>map</var> . <a href="#dom-layers"><code>layers</code></a></dt>
         <dd>
-        <p>Returns an <code>HTMLCollection</code> of the 
+        <p>Returns an <a href="https://dom.spec.whatwg.org/#htmlcollection"><code>HTMLCollection</code></a> of the 
         <a href="#the-layer-element"><code>layer</code></a> element children of the <a href="#the-map-element"><code>map</code></a>.</p>
         </dd>
         </dl>
-        <p>The <code id="dom-areas">areas</code> attribute must return an <code>HTMLCollection</code> 
+        
+        <p>The <code id="dom-areas">areas</code> attribute must return an <a href="https://dom.spec.whatwg.org/#htmlcollection"><code>HTMLCollection</code></a> 
         rooted at the <a href="#the-map-element"><code>map</code></a> element, whose filter matches only  <a href="#the-area-element"><code>area</code></a> child elements.</p>
 
-        <p>The <code id="dom-layers">layers</code> attribute must return an <code>HTMLCollection</code> 
+        <p>The <code id="dom-layers">layers</code> attribute must return an <a href="https://dom.spec.whatwg.org/#htmlcollection"><code>HTMLCollection</code></a> 
         rooted at the <a href="#the-map-element"><code>map</code></a> node, whose filter matches only <a href="#the-layer-element"><code>layer</code></a> child elements of this <a href="#the-map-element"><code>map</code></a> element.</p>
+        
+        <p>The <dfn id="attr-map-zoom"><code>zoom</code></dfn> attribute indirectly identifies an initial scale of the map.</p>
+        <p>The <a href="#dom-htmlmapelement-zoom"><code>zoom</code></a> IDL attribute must <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflect</a> the content attribute of the same name.</p>
+        
+        <p>The <dfn id="attr-map-lat"><code>lat</code></dfn></a> and <dfn id="attr-map-lon"><code>lon</code></dfn> attributes locate the initial center of the map.</p>
+        <p>The <a href="#dom-htmlmapelement-lat"><code>lat</code></a> and <a href="#dom-htmlmapelement-lon"><code>lon</code></a> IDL attributes must <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflect</a> the content attribute of the same name.</p>
 
-        <p>The <code>controls</code> boolean attribute indicates whether default map controls should be displayed on the map.  The nature and position of the controls 
-        is user agent implementation-defined.  The controls can be added or removed by toggling the controls property of the element.
-        </p>
-        <p>The <code>projection</code> attribute value identifies the coordinate system for the map and all the <a href="#the-layer-element"><code>layer</code></a> element children, with the exception of
+        <p>The location and zoom level of the map created with the <a href="#the-map-element"><code>map</code></a> element can be changed via the <code>zoomTo()</code> API method, which will change the <code>zoom</code>, <code>lat</code> and <code>lon</code> properties.</p>
+
+        <p>The <dfn id="attr-map-controls"><code>controls</code></dfn> attribute is a <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute">boolean attribute</a>. If present, it indicates that the author has not provided a scripted controller and would like the user agent to provide its own set of controls.</p>
+        <!-- https://html.spec.whatwg.org/multipage/media.html#user-interface -->
+        <p>If the attribute is present, or if <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-noscript">scripting is disabled</a> for the <a href="https://html.spec.whatwg.org/multipage/media.html#media-element">media element</a>, then the user agent should <dfn id="expose-a-user-interface-to-the-user"><strong>expose a user interface to the user</strong></dfn>.
+          This user interface should include features to zoom in, zoom out, pan to an arbitrary position in the content, and show the media content in manners more suitable to the user (e.g. fullscreen map or in an independent resizable window). Other controls may also be made available.</p>
+        <p>The <a href="#dom-htmlmapelement-controls"><code>controls</code></a> IDL attribute must <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflect</a> the content attribute of the same name.</p>
+        
+        <p>The <dfn id="attr-map-projection"><code>projection</code></dfn> attribute value identifies the coordinate system for the map and all the <a href="#the-layer-element"><code>layer</code></a> element children, with the exception of
         <a href="#the-layer-element"><code>layer</code></a> children in the WGS84 projection.  WGS84 serves as a "wild-card" projection; features encoded in longitude, latitude values according to this projection can often be re-projected for
         use on maps encoded in other projections.  As such, <a href="#the-layer-element"><code>layer</code></a> children do not have a projection attribute, in that they are verified to share the projection declared by their
         parent <a href="#the-map-element"><code>map</code></a> element.  Once established, the projection of the <a href="#the-map-element"><code>map</code></a> is read-only.
         Unless otherwise specified, units are based on pixels projected and transformed from the units of the underlying projection system. The complete definition of these coordinate reference systems can be found in the
         <a href="#tiled-coordinate-reference-systems-table">Tiled Coordinate Reference Systems</a> table.
         </p>
-        <p>The location and zoom level of the map created with the <a href="#the-map-element"><code>map</code></a> element can be changed via the <code>zoomTo(...)</code> API method, which will change the <code>zoom</code>, <code>lat</code> and <code>lon</code> properties.</p>
+        
         <p>The <a href="#the-map-element"><code>map</code></a> element supports the <code>width</code> and <code>height</code> <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">dimension attributes</a>. [[HTML]]</p>
         <p>The <a href="https://drafts.csswg.org/css-images/#default-object-size">default object size</a> is a width of 300 <a href="https://drafts.csswg.org/css-values/#px">CSS pixels</a> and a height of 150 <a href="https://drafts.csswg.org/css-values/#px">CSS pixels</a>. [[css-images-3]]</p>
         </div>
@@ -1560,7 +1570,7 @@
           element does not create any links.
         </p>
         <p>
-          The <dfn id="attr-link-projection"><code>projection</code></dfn> attribute value identifies the TCRS of the linked resource, with a value from the defined set of
+          The <code>projection</code> attribute value identifies the TCRS of the linked resource, with a value from the defined set of
           <a href="#tiled-coordinate-reference-systems-table">TCRS identifiers</a>. When <code>rel=alternate</code> is used together with the <code>projection</code> attribute, clients may be able to perform agent-driven content negotiation
           to provide a better user experience. For example, if an HTML author mistakenly enters the URL of an OSMTILE resource in their HTML <a href="#the-layer-element"><code>layer@src</code></a> attribute, but the <code>map</code> in which the layer takes part is
           declared to be <code>CBMTILE</code>, the MapML author can ease the potential for resultant confusion by providing appropriate <code>rel=alternate</code> links to equivalent MapML resources in other projections.


### PR DESCRIPTION
Fix #92.

Add proper definitions for content attributes, and add IDL content attribute reflections for most `<map>` content attributes.

Also slight re-ordering of a paragraph or two.