### PR TITLE
ReSpec config: replace deprecated `wg` and `wgURI` options with `group`

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -200,8 +200,7 @@
             name: "Elf Pavlik",
           },
         ],
-        wg: "Maps for HTML Community Group",
-        wgURI: "https://www.w3.org/community/maps4html/",
+        group: "maps4html",
         wgPublicList: "public-maps4html",
         edDraftURI: "https://maps4html.org/MapML/spec/",
         copyrightStart: "2015",
@@ -234,7 +233,7 @@
       respecConfig.otherLinks = [
         {
           key: "Join the Community Group",
-          data: [{ value: respecConfig.wg, href: respecConfig.wgURI }],
+          data: [{ value: "Maps for HTML Community Group", href: "https://www.w3.org/community/maps4html/" }],
         },
       ];
     </script>


### PR DESCRIPTION
Fix a ReSpec lint warning about the usage of deprecated config options [`wg`](https://github.com/w3c/respec/wiki/wg) and [`wgURI`](https://github.com/w3c/respec/wiki/wgURI), replaced with [`group`](https://github.com/w3c/respec/wiki/group).