### PR TITLE
Add subsections in the SOTD section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -263,7 +263,7 @@
       </section>
       <section id="sotd">
 
-
+        <section>
         <h3>Intent of this Specification</h3>
         
         <p>This specification describes Map Markup Language (MapML), which is a hypertext document format for maps. This specification is also intended as a proposal to the HTML Working Group to extend the semantics of the <a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element">standard HTML <code>map</code></a> element.</p>
@@ -282,7 +282,8 @@
           directly, but which leverages existing standards where possible and desirable, such as Cascading Style Sheets and OGC Simple Features, for example. MapML will provide an essential part of the contract between Web user agents and
           Web servers when map features are exchanged, in a manner based on the architectural style of the Web, in a similar way to how HTML provides (part of) the contract for documents.
         </p>
-
+        </section>
+        <section>
         <h3>Implementation Experience</h3>
 
         <p>
@@ -295,7 +296,7 @@
         <p>The reader is requested to contact the <a href="mailto:public-maps4html@w3.org">editor</a> with any known implementations of
         Map Markup Language or other implemented support for this proposal.</p>
         <p>The customized built-in HTML <code>&lt;map&gt;</code> element and <code>&lt;mapml-viewer&gt;</code> autonomous custom element were built and are maintained by the Maps for HTML Community Group. [[Web-Map-Custom-Element]]</p>
-
+        </section>
         <details>
           <summary>
             <h3>Changes Since the Previous Draft</h3>
@@ -335,25 +336,28 @@
             
           </ul>
         </details>
-
+        <section>
         <h3>Level of Endorsement by the Community</h3>
 
         <p>Please <a href="https://www.w3.org/community/maps4html/">join</a> the W3C Maps for HTML Community Group if you would like to participate in the development and implementation of this specification.</p>
         <p>You can also star us on <a href="https://github.com/Maps4HTML/MapML">Github</a>.</p>
-
+        </section>
+        <section>
         <h3>Patent Information</h3>
 
         <p>
           Development of this specification together with implementations is done under the terms of the <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">W3C Software Notice and License</a>, in accordance
           with the rules of the W3C Community Groups program.
         </p>
-
+        </section>
+        <section>
         <h3>How to provide feedback</h3>
 
         <p>
           Please send comments on this specification to <a href="mailto:public-maps4html@w3.org">public-maps4html@w3.org</a>, or <a href="https://discourse.wicg.io/t/map-markup-language/1267">WICG</a>, or open an
           <a href="https://github.com/Maps4HTML/MapML/issues">issue</a>.
         </p>
+        </section>
       </section>
 
       <section id="intro" class="informative">


### PR DESCRIPTION
Currently if you click an anchor (§) of any heading inside the [SOTD section](https://maps4html.org/MapML/spec/#sotd) it'll take you to https://maps4html.org/MapML/spec/#sotd.

To fix this, subsections are wrapped in `section` elements, for ReSpec to generate unique IDs for each subsection.