### PR TITLE
Meta: remove opinionated font styles for definitions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -9,13 +9,6 @@
       height: auto;
       max-width: 100%;
     }
-    :root h2,
-    :root h3,
-    :root h4,
-    :root h5,
-    :root h6 {
-      font-weight: normal;
-    }
     :root details {
       margin: 2.5rem 0 1.5rem 0;
     }
@@ -43,7 +36,6 @@
     :root table.def th {
       white-space: nowrap;
       padding-left: 0;
-      font-style: normal;
     }
     :root .respec-button-copy-paste {
       left: auto;
@@ -81,10 +73,6 @@
     }
     :root dl.def dd + dt {
       margin-top: 0.75em;
-    }
-    :root h5,
-    :root section h4 dfn {
-      font-style: normal;
     }
     :root code,
     :root .hljs-deletion,

--- a/spec/index.html
+++ b/spec/index.html
@@ -9,11 +9,6 @@
       height: auto;
       max-width: 100%;
     }
-    :root .def dfn,
-    :root .idlSuperclass {
-      font-style: normal;
-      font-weight: normal;
-    }
     :root h2,
     :root h3,
     :root h4,


### PR DESCRIPTION
When integrating ReSpec I introduced these font styles, which aren't great. Retaining the default italic styles (from the ReSpec stylsheet) for definitions is helpful as it indicates a `<dfn>` (usually clickable to expand a list of references to that definition).