### PR TITLE
Update GeoServer reference

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -217,8 +217,8 @@
             publisher: "The Open Source Geospatial Foundation"
           },
           "GeoServer": {
-            title: "GeoServer MapML Community Module",
-            href: "https://docs.geoserver.org/latest/en/user/community/mapml/index.html",
+            title: "GeoServer MapML Extension",
+            href: "https://docs.geoserver.org/latest/en/user/extensions/mapml/index.html",
             publisher: "W3C Maps for HTML Community Group"
           },
           "GDAL" : {


### PR DESCRIPTION
Fix #169.

Updates the GeoServer reference from MapML Community Module to Extension.