### PR TITLE
Fix ReSpec warning: Insecure URLs are not allowed in `respecConfig`

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -203,7 +203,7 @@
           },
           "EPSG-REGISTRY": {
             title: "EPSG Geodetic Parameter Dataset",
-            href: "http://www.epsg-registry.org/",
+            href: "https://epsg.org/home.html",
             publisher: "International Association of Oil ans Gas Producers",
           },
           "UCR-Web-Maps": {


### PR DESCRIPTION
http://www.epsg-registry.org/ now redirects to https://epsg.org/home.html, changing the URL, which is also https:// so fixes a ReSpec warning.