### PR TITLE
Add `nopan` keyword to `controlslist` + mention the Layer control feature in "expose a user interface to the user"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -627,8 +627,20 @@
 
         <p>The <dfn id="attr-map-controls"><code>controls</code></dfn> attribute is a <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attribute">boolean attribute</a>. If present, it indicates that the author has not provided scripted controls and would like the user agent to provide its own set of controls.</p>
         <!-- https://html.spec.whatwg.org/multipage/media.html#user-interface -->
-        <p>If the attribute is present, or if <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-noscript">scripting is disabled</a> for the media element, then the user agent should <dfn id="expose-a-user-interface-to-the-user"><strong>expose a user interface to the user</strong></dfn>.
-          This user interface should include features to zoom in, zoom out, pan to an arbitrary position in the content, and show the media content in manners more suitable to the user (e.g. fullscreen map or in an independent resizable window). Other controls may also be made available.</p>
+        <p>
+          If the attribute is present,
+          or if <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-noscript">scripting is disabled</a>
+          for the media element,
+          then the user agent should
+          <dfn id="expose-a-user-interface-to-the-user"><strong>expose a user interface to the user</strong></dfn>.
+          This user interface should include features to
+          zoom in,
+          zoom out,
+          pan to an arbitrary position in the content,
+          and show the media content in manners more suitable to the user
+          (e.g. fullscreen map or in an independent resizable window).
+          Other controls may also be made available.
+        </p>
         <p>The <a href="#dom-htmlmapelement-controls"><code>controls</code></a> IDL attribute must <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">reflect</a> the content attribute of the same name.</p>
         
         <p>The <dfn id="attr-map-controlslist"><code>controlslist</code></dfn> attribute, when specified, helps the user agent select what controls to show on the media element whenever the user agent shows its own set of controls.

--- a/spec/index.html
+++ b/spec/index.html
@@ -637,6 +637,7 @@
           zoom in,
           zoom out,
           pan to an arbitrary position in the content,
+          toggle the "on/off" status of layers,
           and show the media content in manners more suitable to the user
           (e.g. fullscreen map or in an independent resizable window).
           Other controls may also be made available.

--- a/spec/index.html
+++ b/spec/index.html
@@ -649,12 +649,14 @@
           The allowed values are
           <dfn id="attr-map-controlslist-nofullscreen"><code>nofullscreen</code></dfn>,
           <dfn id="attr-map-controlslist-nolayer"><code>nolayer</code></dfn>,
+          <dfn id="attr-map-controlslist-nopan"><code>nopan</code></dfn>,
           <dfn id="attr-map-controlslist-noreload"><code>noreload</code></dfn>
           and <dfn id="attr-map-controlslist-nozoom"><code>nozoom</code></dfn>.
         </p>
           
         <p>The <a href="#attr-map-controlslist-nofullscreen"><code>nofullscreen</code></a> keyword hints that the fullscreen mode control should be hidden when using the user agent's own set of controls for the media element.</p>
         <p>The <a href="#attr-map-controlslist-nolayer"><code>nolayer</code></a> keyword hints that the layer control should be hidden when using the user agent's own set of controls for the media element.</p>
+        <p>The <a href="#attr-map-controlslist-nopan"><code>nopan</code></a> keyword hints that the pan controls should be hidden when using the user agent's own set of controls for the media element.</p>
         <p>The <a href="#attr-map-controlslist-noreload"><code>noreload</code></a> keyword hints that the reload control should be hidden when using the user agent's own set of controls for the media element.</p>
         <p>The <a href="#attr-map-controlslist-nozoom"><code>nozoom</code></a> keyword hints that the zoom controls should be hidden when using the user agent's own set of controls for the media element.</p>
         


### PR DESCRIPTION
- [x] https://github.com/Maps4HTML/MapML/commit/c8b2b8e6710eb8e51c1fb39487517c5a70868699 adds the `nopan` keyword to `controlslist`. Fixes #137.
- [x] https://github.com/Maps4HTML/MapML/commit/19b26066906f5ab9230143e9e0deb19cca9ab4eb mentions the Layer control feature in "expose a user interface to the user". Fixes #138.