### PR TITLE
Remove link to "Latest published version", which returns a 404

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -16,6 +16,7 @@
     <script class="remove">
       var respecConfig = {
         specStatus: "CG-DRAFT",
+        latestVersion: null,
         editors: [
           {
             name: "Peter Rushforth",


### PR DESCRIPTION
Prevents ReSpec from generating:

> **Latest published version:**
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;https://www.w3.org/TR/MapML/