### PR TITLE
Remove trailing slash from HTML namespace

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -242,7 +242,7 @@
         <p>
           This specification describes Map Markup Language (MapML), which is an extended subset of HTML, for maps.
           MapML extends the semantics of several  [[[HTML]]] elements, and specifies a small set of new, mapping-specific 
-          elements, in the HTML namespace ("http://www.w3.org/1999/xhtml/"). 
+          elements, in the HTML namespace ("http://www.w3.org/1999/xhtml"). 
         </p>
 
         <p>MapML is designed to specify a declarative markup vocabulary that "implements" some of the capabilities 
@@ -1451,7 +1451,7 @@
           A MapML document is an XML document, with all elements assigned to the HTML namespace. As such, 
           a MapML document MUST have a single root element named <a href="#the-mapml-element"><code>mapml
           </code></a>, generally having a single attribute named "xmlns" with a value which MUST be equal 
-          to "http://www.w3.org/1999/xhtml/".  Assigning elements to namespaces using namepace prefixes 
+          to "http://www.w3.org/1999/xhtml".  Assigning elements to namespaces using namepace prefixes 
           is NOT recommended. At this time, there is only an XML syntax variety of MapML document, and 
           documents conforming to this specification MUST NOT have a <code>DOCTYPE</code> declaration.
         </p>


### PR DESCRIPTION
https://infra.spec.whatwg.org/#html-namespace:

> The HTML namespace is "`http://www.w3.org/1999/xhtml`".

Validators complain about this, not sure if there are other actual implications of a trailing slash in the HTML namespace.