### PR TITLE
Update schema (rnc) and schematron (sch) to support map-a

### DIFF
--- a/schema/mapml.rnc
+++ b/schema/mapml.rnc
@@ -33,9 +33,6 @@ body = element body { bodyContent }
 bodyContent =  extent? & links & (feature | tile | image)*  
 extent = element extent {
   attribute units  { "OSMTILE" | "CBMTILE" | "APSTILE" | "WGS84" }?,
-  attribute action { xsd:anyURI }?, 
-  attribute method { "get" | "GET" }?,
-  attribute enctype { "application/x-www-form-urlencoded" }?,
   (inputs* & datalist* & links* & select* & label*)?
 }
 inputs = (element input {
@@ -51,10 +48,10 @@ inputs = (element input {
   # https://developer.mozilla.org/en-US/docs/Web/CSS/object-position 
   attribute position { "top-left" | "top-right" | "bottom-left" | "bottom-right" | "center-left" | "center-right" | "top-center" | "bottom-center" | "center" }?,
   attribute axis { "latitude" | "longitude" | "easting" | "northing" | "x" | "y" | "row" | "column" | "i" | "j" }?,
-  attribute units {"tilematrix" | "pcrs" | "tcrs" | "map" | "gcrs" | "tile" }?,
+  attribute units {"gcrs" | "pcrs" | "tcrs" | "map" | "tilematrix" | "tile" }?,
   attribute required { xsd:boolean }?,
-  attribute min { xsd:decimal }?,
-  attribute max { xsd:decimal }?,
+  attribute min { xsd:double }?,
+  attribute max { xsd:double }?,
   attribute step { text }?
 })
 datalist = element datalist {
@@ -88,7 +85,11 @@ tile = element tile {
 }
 bbox = element bbox { twoPositions }
 image =    element image { ImageModel }
-geometry = element geometry { GeometryContent }
+
+geometry = element geometry {
+  attribute cs { "gcrs" | "pcrs" | "tcrs" | "map" | "tilematrix" | "tile" }?,
+  (GeometryContent | map-a)
+  }
 properties = element properties { PropertyContent }
 featurecaption = element featurecaption { text? }
 
@@ -107,23 +108,28 @@ any_attribute = attribute * { text }
 imageLocation = attribute x { xsd:double }, attribute y { xsd:double }
 imageSize = attribute width { xsd:integer },attribute height { xsd:integer }
 
-GeometryContent = point | linestring | polygon | multipoint | multilinestring | multipolygon | geometrycollection   
-point = element point { coordinates_mixed }
-linestring = element linestring { coordinates_mixed }
-polygon = element polygon { coordinates_mixed+ }
-multipoint = element multipoint { coordinates_mixed }
-multilinestring = element multilinestring { coordinates_mixed+ }
-multipolygon = element multipolygon { polygon+ }
+GeometryContent =  point | linestring | polygon | multipoint | multilinestring | multipolygon | geometrycollection
+map-a = element map-a { 
+  attribute href { text },
+  attribute target { "_self" | "_top" | "_blank" | "_parent" }?,
+  attribute type { "text/mapml" | "text/html" }?,
+  (GeometryContent | text | span_element | coordinates_mixed)}
+point = element point { map-a | coordinates_mixed }
+linestring = element linestring { map-a | coordinates_mixed }
+polygon = element polygon { map-a* & coordinates_mixed+ }
+multipoint = element multipoint { map-a | coordinates_mixed }
+multilinestring = element multilinestring { map-a* & coordinates_mixed+ }
+multipolygon = element multipolygon { map-a* & polygon+ }
 geometrycollection = element geometrycollection {
     (point* & linestring* & polygon* & multipoint* & multilinestring* & multipolygon*)
 }
-# TODO: allow either span OR a, and possibly others.
 span_element = element span { 
                   mixed {
                     attribute * { text }*&
-                    span_element* 
+                    span_element* &
+                    map-a*
                   }
                }
-coordinates_mixed = element coordinates  { mixed { span_element* } } 
+coordinates_mixed = element coordinates  { mixed { span_element* & map-a* } } 
 # for bbox content, omits coordinates element
 twoPositions =  list  { (xsd:double, xsd:double, xsd:double, xsd:double) } 

--- a/schema/mapml.sch
+++ b/schema/mapml.sch
@@ -1,115 +1,112 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
-    xmlns:sqf="http://www.schematron-quickfix.com/validator/process" xmlns:xs="http://www.w3.org/2001/XMLSchema-datatypes" >
-    <sch:pattern >
-        <sch:rule context="input[@type='location'][@units eq 'tilematrix'][@axis eq 'row' or @axis eq 'column']">
+<sch:schema  xmlns:sch="http://purl.oclc.org/dsdl/schematron" queryBinding="xslt2"
+    xmlns:sqf="http://www.schematron-quickfix.com/validator/process" xmlns:xs="http://www.w3.org/2001/XMLSchema-datatypes" xmlns="http://www.w3.org/1999/xhtml">
+    <sch:ns uri="http://www.w3.org/1999/xhtml"  prefix="h"/>
+    <sch:pattern  >
+        <sch:rule context="h:input[@type='location'][@units eq 'tilematrix'][@axis eq 'row' or @axis eq 'column']">
             <sch:assert test="./@rel eq 'map' or not(./@rel)">For inputs[@type=location], @rel must equal 'map' or not exist</sch:assert>
         </sch:rule>
-        <sch:rule context="input[@type='location'][@units eq 'map']">
+        <sch:rule context="h:input[@type='location'][@units eq 'map']">
             <sch:assert test="./@axis eq 'j' or ./@axis eq 'i'">For inputs[@type=location][units=map] @axis must exist and be equal to either i or j</sch:assert>
         </sch:rule>
-        <sch:rule context="input[@type='location'][@axis eq 'easting']">
-            <sch:assert test="exists(preceding-sibling::input[@axis eq 'northing']) or exists(following-sibling::input[@axis eq 'northing'])">Easting axis reference must have paired northing axis reference</sch:assert>
+        <sch:rule context="h:input[@type='location'][@axis eq 'easting']">
+            <sch:assert test="exists(preceding-sibling::h:input[@axis eq 'northing']) or exists(following-sibling::h:input[@axis eq 'northing'])">Easting axis reference must have paired northing axis reference</sch:assert>
         </sch:rule>
-        <sch:rule context="input[@type='location'][@axis eq 'northing']">
-            <sch:assert test="exists(preceding-sibling::input[@axis eq 'easting']) or exists(following-sibling::input[@axis eq 'easting'])">Northing axis reference must have paired easting axis reference</sch:assert>
+        <sch:rule context="h:input[@type='location'][@axis eq 'northing']">
+            <sch:assert test="exists(preceding-sibling::h:input[@axis eq 'easting']) or exists(following-sibling::h:input[@axis eq 'easting'])">Northing axis reference must have paired easting axis reference</sch:assert>
         </sch:rule>
-        <sch:rule context="input[@type='hidden'][@shard]">
+        <sch:rule context="h:input[@type='hidden'][@shard]">
             <sch:assert test="exists(./@list)">A shard-type input must have a @list attribute</sch:assert>
             <sch:let name="listid" value="./@list"></sch:let>
-            <sch:assert test="exists(//datalist[@id eq $listid])">A datalist must be associated to a shard-type input</sch:assert>
+            <sch:assert test="exists(//h:datalist[@id eq $listid])">A datalist must be associated to a shard-type input</sch:assert>
             <sch:report test="exists(./@value)">A shard-type input must not have a @value</sch:report>
         </sch:rule>
-        <sch:rule context="input[@shard]">
+        <sch:rule context="h:input[@shard]">
             <sch:assert test=".[@type eq 'hidden']">A shard-type input must have @type="hidden"</sch:assert>
         </sch:rule>
-        <sch:rule context="extent">
-            <sch:assert test="input[@type eq 'zoom']">Extent must have a zoom input</sch:assert>
-            <sch:assert test="(count((input[@type='location'][@axis eq 'i'] union input[@type='location'][@axis eq 'j'])) mod 2) eq 0">location inputs with axis=i or j must come in pairs</sch:assert>
-            <sch:assert test="(count(input[@type='location'][@axis eq 'easting' or @axis eq 'northing']) mod 2) eq 0">location inputs with axis=easting or northing must come in pairs</sch:assert>
-            <sch:assert test="(count(input[@type='location'][@axis eq 'latitude' or @axis eq 'longitude']) mod 2) eq 0">location inputs with axis=latitude or longitude must come in pairs</sch:assert>
-            <sch:assert test="(count(input[@type='location'][@axis eq 'row' or @axis eq 'column']) mod 2) eq 0">location inputs with axis=row or column must come in pairs</sch:assert>
-            <sch:assert test="(count(input[@type='location'][@axis eq 'x' or @axis eq 'y']) mod 2) eq 0">location inputs with axis=x or y must come in pairs</sch:assert>
-            <sch:report test="(exists(@method) and not(exists(@action)))">An extent with a method attribute must have an action attribute</sch:report>
+        <sch:rule context="h:extent">
+            <sch:assert test="h:input[@type eq 'zoom']">Extent must have a zoom input</sch:assert>
+            <sch:assert test="(count((h:input[@type='location'][@axis eq 'i'] union h:input[@type='location'][@axis eq 'j'])) mod 2) eq 0">location inputs with axis=i or j must come in pairs</sch:assert>
+            <sch:assert test="(count(h:input[@type='location'][@axis eq 'easting' or @axis eq 'northing']) mod 2) eq 0">location inputs with axis=easting or northing must come in pairs</sch:assert>
+            <sch:assert test="(count(h:input[@type='location'][@axis eq 'latitude' or @axis eq 'longitude']) mod 2) eq 0">location inputs with axis=latitude or longitude must come in pairs</sch:assert>
+            <sch:assert test="(count(h:input[@type='location'][@axis eq 'row' or @axis eq 'column']) mod 2) eq 0">location inputs with axis=row or column must come in pairs</sch:assert>
+            <sch:assert test="(count(h:input[@type='location'][@axis eq 'x' or @axis eq 'y']) mod 2) eq 0">location inputs with axis=x or y must come in pairs</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="extent[@action]">
-            <sch:assert test="input and (count(link[@rel='query']) eq 1 or not(exists(link[@rel='query'])))"> Extent Content model: If the action attribute exists: A set of multiple input and zero or one link element with its rel attribute in the "query" state.</sch:assert>
-        </sch:rule>
-        <sch:rule context="extent[not(@action)]">
-            <sch:assert test="input and link[@rel=('tile','image','features')] and count(link[@rel eq 'query']) &lt;= 1"> Extent Content model:  If no action attribute exists: A set of multiple input and one or more link elements with their rel attribute in either the "tile", "image" or "features" state, and zero or one link element with its rel attribute in the "query" state.</sch:assert>     
+        <sch:rule context="h:extent">
+            <sch:assert test="h:input and h:link[@rel=('tile','image','features')] and count(h:link[@rel eq 'query']) &lt;= 1"> Extent Content model:  A set of multiple input and one or more link elements with their rel attribute in either the "tile", "image" or "features" state, and zero or one link element with its rel attribute in the "query" state.</sch:assert>     
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="head/link">
+        <sch:rule context="h:head/h:link">
             <sch:assert test="exists(@href)">Links in head should have a href attribute (head links should not be templated).</sch:assert>
             <sch:report test="exists(@tref)">Links in head should not have a tref attribute (head links should not be templated).</sch:report>
             <sch:let name="recognizedRels" value="'alternate' , 'stylesheet' , 'license' , 'self' , 'style' , 'self style', 'style self', 'legend', 'next', 'zoomin', 'zoomout'"></sch:let>
             <sch:assert test="exists(@rel) and @rel = $recognizedRels">Unrecognized link@rel value (for head link): <sch:value-of select="@rel"/>. Recognized rel values are: <sch:value-of select="$recognizedRels"/></sch:assert>
         </sch:rule>
-        <sch:rule context="head/link[@type]">
+        <sch:rule context="h:head/h:link[@type]">
             <sch:let name="recognizedTypes" value="'text/html','text/css','text/mapml'"></sch:let>
             <sch:report test="@type = $recognizedTypes">Unrecognized link@type value (for head link): <sch:value-of select="@type"/>. Recognized types are: <sch:value-of select="$recognizedTypes"/></sch:report>
         </sch:rule>
-        <sch:rule context="head/link[@projection]">
+        <sch:rule context="h:head/h:link[@projection]">
             <sch:report test="@rel ne 'alternate'">projection links must be rel="alternate"</sch:report>
             <sch:report test="exists(@type) and @type ne 'text/mapml'">If alternate projections are provided, the @type must be 'text/mapml', or be unspecified</sch:report>
             <sch:let name="recognizedProjections" value="'OSMTILE' , 'WGS84', 'CBMTILE', 'APSTILE'"></sch:let>
             <sch:report test="upper-case(@projection) = $recognizedProjections">Unrecognized link@projection value:  <sch:value-of select="@projection"/></sch:report>
         </sch:rule>
-        <sch:rule context="extent/link">
+        <sch:rule context="h:extent/h:link">
             <sch:assert test="exists(@tref)">Links in extent should have a tref attribute (extent links must be templated).</sch:assert>
             <sch:report test="exists(@href)">Links in extent should not have a href attribute (extent links must be templated).</sch:report>
             <sch:let name="recognizedRels" value="'image' , 'tile' , 'query' , 'features'"></sch:let>
             <sch:assert test="exists(@rel) and @rel = $recognizedRels">Unrecognized link@rel value (for templated link): <sch:value-of select="@rel"/>. Recognized rel values are: <sch:value-of select="$recognizedRels"/></sch:assert>
         </sch:rule>
-        <sch:rule context="extent/link[@type]">
+        <sch:rule context="h:extent/h:link[@type]">
             <sch:let name="recognizedTypes" value="'text/mapml','image/png','image/jpeg'"></sch:let>
             <sch:assert test="@type = $recognizedTypes">Unrecognized link@type value (for templated link): <sch:value-of select="@type"/>. Recognized types are: <sch:value-of select="$recognizedTypes"/></sch:assert>
         </sch:rule>
-        <sch:rule context="input[@name = preceding-sibling::input/@name]">
+        <sch:rule context="h:input[@name = preceding-sibling::h:input/@name]">
             <sch:assert test="false()">Duplicate input/@name detected</sch:assert>
         </sch:rule>
-        <sch:rule context="input[@type eq 'location' or @type eq 'zoom'][@min][@max][xs:decimal(@min) &gt; xs:decimal(@max)]">
+        <sch:rule context="h:input[@type eq 'location' or @type eq 'zoom'][@min][@max][xs:double(@min) &gt; xs:double(@max)]">
             <sch:assert test="false()">@min &gt; @max detected</sch:assert>
         </sch:rule>
-        <sch:rule context="link[@tref]">
+        <sch:rule context="h:link[@tref]">
             <sch:assert test="local-name(parent::node()) eq 'extent'">templated links can only be in the extent element</sch:assert>
         </sch:rule>
-        <sch:rule context="link[@projection]">
+        <sch:rule context="h:link[@projection]">
             <!-- this rule doesn't work. don't know why. <sch:assert test="./@rel eq 'alternate'">For alternate projection links, @rel must equal 'alternate'</sch:assert>-->
             <sch:assert test="local-name(parent::node()) eq 'head'">Alternate projection links can only be in the head element</sch:assert>
         </sch:rule>
-        <sch:rule context="link[@href]">
+        <sch:rule context="h:link[@href]">
             <sch:assert test="local-name(parent::node()) ne 'extent'">regular links must not be in the extent element</sch:assert>
         </sch:rule>
-        <sch:rule context="link[normalize-space(@rel) = 'self style' or normalize-space(@rel) = 'style self']">
-            <sch:assert test="count(//link[normalize-space(@rel) = 'self style' or normalize-space(@rel) = 'style self']) eq 1">More than one self style or style self link found</sch:assert>
+        <sch:rule context="h:link[normalize-space(@rel) = 'self style' or normalize-space(@rel) = 'style self']">
+            <sch:assert test="count(//h:link[normalize-space(@rel) = 'self style' or normalize-space(@rel) = 'style self']) eq 1">More than one self style or style self link found</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="label">
+        <sch:rule context="h:label">
             <sch:assert test="exists(./@for)">A label must have a @for attribute</sch:assert>
             <sch:let name="forid" value="./@for"></sch:let>
             <sch:assert test="exists(//*[@id eq $forid])">A label must be associated to another element by label@for == element@id</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="select[@id]">
+        <sch:rule context="h:select[@id]">
             <sch:let name="forid" value="./@id"></sch:let>
-            <sch:assert test="count(//label[@for eq $forid]) eq 1">There must be only one label per labelled (select) element. Duplicated label for id="<sch:value-of select="$forid"/>".</sch:assert>
+            <sch:assert test="count(//h:label[@for eq $forid]) eq 1">There must be only one label per labelled (select) element. Duplicated label for id="<sch:value-of select="$forid"/>".</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="coordinates">
+        <sch:rule context="h:coordinates">
             <sch:let name="cs" value="tokenize(normalize-space(string-join((descendant::text()),' ')),' ')"></sch:let>
             <sch:assert test="(count($cs) mod 2) eq 0">Coordinates must be a sequence of number pairs</sch:assert>
             <sch:assert test="every $c in $cs satisfies ($c castable as xs:double)">Coordinates must all be numeric</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="polygon/coordinates">
+        <sch:rule context="h:polygon//h:coordinates">
             <sch:let name="cs" value="tokenize(normalize-space(string-join((descendant::text()),' ')),' ')"></sch:let>
             <sch:assert test="(count($cs) idiv 2) ge 3">A polygon's coordinates must be a sequence of three or more pairs of numbers</sch:assert>
             <sch:let name="first" value="subsequence($cs,1,2)"></sch:let>
@@ -118,19 +115,20 @@
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="(multilinestring|linestring)/coordinates ">
+        <!-- -->
+        <sch:rule context="(h:multilinestring|h:linestring)//h:coordinates ">
             <sch:let name="cs" value="tokenize(normalize-space(string-join((descendant::text()),' ')),' ')"></sch:let>
             <sch:assert test="(count($cs) idiv 2) ge 2">A linestring's coordinates must be a sequence of two or more pairs of numbers</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="multipoint/coordinates ">
+        <sch:rule context="h:multipoint//h:coordinates ">
             <sch:let name="cs" value="tokenize(normalize-space(string-join((descendant::text()),' ')),' ')"></sch:let>
             <sch:assert test="(count($cs) idiv 2) ge 2">A multipoint's coordinates should be a sequence of two or more pairs of numbers. Should you use a point, instead?</sch:assert>
         </sch:rule>
     </sch:pattern>
     <sch:pattern>
-        <sch:rule context="coordinates//span">
+        <sch:rule context="h:coordinates//h:span">
             <sch:let name="cs" value="tokenize(normalize-space(string-join((descendant::text()),' ')),' ')"></sch:let>
             <sch:assert test="(count($cs) mod 2) eq 0">A span in coordinates should wrap coordinate pairs.</sch:assert>
             <!-- TODO: a test that the first number in a span is an odd number of positions into the overall set of tokens i.e. 1,3,5, etc -->


### PR DESCRIPTION
Update / convert to html namespace, required a bit of fiddling to schematron.  
Remove `extent@action`, `extent@method`, `extent@enctype` as these are no longer supported / proposed. 
Change the datatype for validation of `min`,`max` attributes to xsd:double, which supports scientific notation better than xs:decimal

- seems to work :-), may be useful.