### PR TITLE
Clarify reference to 'extent'

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1422,7 +1422,7 @@
         <h4 id="extent-semantics">Extents</h4>
         <p>
           A MapML document is a representation of a defined portion of a two dimensional 
-          map area. In MapML, this is called an 'extent' (see below), the extremes 
+          map area. In MapML, this is called an 'extent' (represented by the <a href="#the-extent-element"><code>extent</code></a> element), the extremes 
           of which can be described in terms of locations coordinates specified 
           in the TCRS (pcrs, gcrs, tilematrix, etc.).
           The <code>extent/@units</code> value SHALL be taken to be the authoritative 


### PR DESCRIPTION
I think "see below" refers to the `extent` element.

Fix https://github.com/Maps4HTML/MapML/issues/218.